### PR TITLE
Add accepted legacy RFCs

### DIFF
--- a/active-rfcs/add-prettier-plugin-to-vscode-extension.md
+++ b/active-rfcs/add-prettier-plugin-to-vscode-extension.md
@@ -1,0 +1,23 @@
+<!-- LEGACY RFC -->
+<p align="center"><strong>⚠️⚠️⚠️ Legacy RFC Disclaimer ⚠️⚠️⚠️
+<br />This RFC does not meet the requirements of the current RFC process.
+<br />It was accepted before the current process was created.
+<br /><a href="https://github.com/withastro/rfcs#readme">Learn more about the RFC standards.</a>
+</strong></p>
+<!-- LEGACY RFC -->
+
+---
+
+- Start Date: 2021-06-13
+- Reference Issues: N/A
+- Implementation PR: N/A
+
+# Summary
+
+Add prettier plugin to VSCode extension.
+
+- A few people (including myself, embarassingly) didn't realize that there was a prettier plugin for Astro files
+- Reading up on Svelte's support, it looks like they bundle their formatter in with their VSCode extension
+- see: https://github.com/sveltejs/language-tools/tree/master/packages/svelte-vscode
+
+We should look into doing this ourselves! Almost all Astro users use the VSCode extension, so format-on-save should then be enabled by default.

--- a/active-rfcs/add-test-tool-for-astro-components.md
+++ b/active-rfcs/add-test-tool-for-astro-components.md
@@ -1,0 +1,29 @@
+<!-- LEGACY RFC -->
+<p align="center"><strong>⚠️⚠️⚠️ Legacy RFC Disclaimer ⚠️⚠️⚠️
+<br />This RFC does not meet the requirements of the current RFC process.
+<br />It was accepted before the current process was created.
+<br /><a href="https://github.com/withastro/rfcs#readme">Learn more about the RFC standards.</a>
+</strong></p>
+<!-- LEGACY RFC -->
+
+---
+
+- Start Date: 2021-06-18
+- Reference Issues: N/A
+- Implementation PR: N/A
+
+# Summary
+
+Provide a way to test Astro components, perhaps by publishing the `astro` test setup.
+
+**Background & Motivation**:
+
+I want to be able to setup tests for https://github.com/jasikpark/astro-katex to make sure it works correctly, but I have not clue how to do that without either adding it to `astro/packages/astro/components/KaTeX.astro` and using the current monorepo testing rig, or by manually testing it.
+
+**Proposed Solution**:
+
+- Publish the helpers and whatnot as an astro package 🤔 or allow copying of the setup for the moment.
+
+**Risks, downsides, and/or tradeoffs**:
+
+- Seems like a lot of support to add, but testing astro components seems like a worthy goal.

--- a/active-rfcs/replace-prism-with-shiki.md
+++ b/active-rfcs/replace-prism-with-shiki.md
@@ -1,0 +1,80 @@
+<!-- LEGACY RFC -->
+<p align="center"><strong>⚠️⚠️⚠️ Legacy RFC Disclaimer ⚠️⚠️⚠️
+<br />This RFC does not meet the requirements of the current RFC process.
+<br />It was accepted before the current process was created.
+<br /><a href="https://github.com/withastro/rfcs#readme">Learn more about the RFC standards.</a>
+</strong></p>
+<!-- LEGACY RFC -->
+
+---
+
+- Start Date: 2021-06-24
+- Reference Issues: N/A
+- Implementation PR: N/A
+
+# Summary
+
+Replace Prism with Shiki.
+
+**Background & Motivation**:
+
+There's been significant interest in our Discord to replace Prism with Shiki:
+
+- @tusharsadhwani https://discord.com/channels/830184174198718474/872579324446928896/875712505287176192
+- @obnoxiousnerd https://discord.com/channels/830184174198718474/845451724738265138/862567271117226015
+- @aFuzzyBear: https://discord.com/channels/830184174198718474/845451724738265138/862294768519479327
+- @natemoo-re: https://discord.com/channels/830184174198718474/853350631389265940/857021165754777601
+- @sarah11918 https://discord.com/channels/830184174198718474/845430950191038464/879503310938316800
+- @FredKSchott
+
+There are several objective reasons to want Shiki over Prism, besides just hype:
+
+- Shiki supports all VSCode themes directly, with several popular themes built-in.
+- Shiki supports 100+ built-in, popular language grammars (including Astro! https://github.com/shikijs/shiki/pull/205)
+- Shiki language grammars are the same as Github, VSCode, etc, guaranteeing that they are up-to-date.
+- Shiki language grammars are updated for patches/fixes on every release.
+- Shiki has a growing community around it. Prism has its ecosystem, which is large but not actively worked on by anyone. See https://github.com/shikijs/shiki#seen
+- https://www.typescriptlang.org/ has invested heavily in Shiki, so there's confidence that it is battle tested.
+
+There's some neat things going on behind the scenes, as well:
+
+Shiki controls theming, so that the end result is `<span style="color: #XXXXXX">` instead of `<span class="token token-comment">`. This is objectively better for a tool like Astro because it accomplishes the exact same thing but without global classes that leak into our users projects.
+
+**Proposed Solution**:
+
+Phase 1: Today:
+
+- Add a new `<Code>` component, powered by Shiki. More info below. It lives alongside `<Prism>`.
+- **success metric to continue to phase 2:** happy user reports of anyone using the `<Code>` component directly
+
+Phase 2: Soon:
+
+- **requires:** a way to set a global theme, across your site/project
+- **requires:** a way to customize your markdown syntax highlighter of choice
+- Move Markdown code blocks to use `<Code>` instead of `<Prism>` (https://github.com/stefanprobst/remark-shiki)
+- Move our recommendation in docs to use `<Code>` over `<Prism>`, but keep references to `<Prism>`.
+- Add warning when you use `<Prism>` to use `<Code>`  instead.
+- **success metric to continue to phase 3:** docs site happy with the new Code component (usage in markdown)
+
+Phase 3: v1.0:
+
+- Remove `<Prism>` entirely.
+- Move it into a seperate component, for anyone who still wants it. ex:`import Prism from '@astrojs/prism';` 
+
+**Detailed Design**:
+
+```astro
+---
+// Example Implementation
+// Usage: import {Code} from 'astro/components';
+import shiki from 'shiki';
+const { code, lang = 'plaintext', theme = 'nord' } = Astro.props;
+const highlighter = await shiki.getHighlighter({theme});
+const html = highlighter.codeToHtml(code, lang);
+---
+{html}
+```
+
+**Draft PR**:
+
+https://github.com/snowpackjs/astro/pull/1208

--- a/active-rfcs/support-draft-markdown-posts.md
+++ b/active-rfcs/support-draft-markdown-posts.md
@@ -1,0 +1,29 @@
+<!-- LEGACY RFC -->
+<p align="center"><strong>⚠️⚠️⚠️ Legacy RFC Disclaimer ⚠️⚠️⚠️
+<br />This RFC does not meet the requirements of the current RFC process.
+<br />It was accepted before the current process was created.
+<br /><a href="https://github.com/withastro/rfcs#readme">Learn more about the RFC standards.</a>
+</strong></p>
+<!-- LEGACY RFC -->
+
+---
+
+- Start Date: 2021-06-14
+- Reference Issues: N/A
+- Implementation PR: N/A
+
+# Summary
+
+Add `draft` support for Markdown posts.
+
+**What is Missing from Astro Today?**
+
+- `draft` as a top-level primitive for Markdown posts/files 
+- `buildOptions.drafts` as an option to ignore posts/files with `draft: true`
+- borrowed from: https://jekyllrb.com/docs/configuration/options/ 
+
+**Proposed Solution**
+
+Implement this to match Jekyll.
+
+As a stretch goal, we could also add the `published: true/false` syntax instead. This is similar, but `draft=true` can still be built if `--drafts` is used when you build. `published=false` will never make it into your build, no matter what.

--- a/active-rfcs/support-exports-from-astro-components.md
+++ b/active-rfcs/support-exports-from-astro-components.md
@@ -1,0 +1,55 @@
+<!-- LEGACY RFC -->
+<p align="center"><strong>⚠️⚠️⚠️ Legacy RFC Disclaimer ⚠️⚠️⚠️
+<br />This RFC does not meet the requirements of the current RFC process.
+<br />It was accepted before the current process was created.
+<br /><a href="https://github.com/withastro/rfcs#readme">Learn more about the RFC standards.</a>
+</strong></p>
+<!-- LEGACY RFC -->
+
+---
+
+- Start Date: 2021-06-17
+- Reference Issues: N/A
+- Implementation PR: N/A
+
+# Summary
+
+Allow exports from astro components.
+
+**Background & Motivation**:
+
+Related to https://github.com/withastro/astro/issues/491
+
+I think an interesting pattern we could support is allowing astro files to export data:
+
+```astro
+---
+import Markdown from "@astro/components";
+import MainLayout from "@layouts/MainLayout.astro";
+import Header from "@components/Header.astro";
+export const title = "This is a title";
+export const date = new Date("2021-08-17");
+export const author = "McAuthor AuthorPants";
+---
+
+<MainLayout>
+  <Markdown>
+    <Header title={title}/>
+    Hiya this is my content
+  </Markdown>
+</MainLayout>
+```
+
+- And then `Astro.fetchContent("**/*.astro")` would return a similar object to `Astro.fetchContent("**/*.md")` allowing components in markdown without too much effort..
+- `import {...} from './SomeComponent.astro'` would return these exports.
+
+**Proposed Solution**:
+
+- At compile-time, all exported things are hoisted out of the render function (similar to what we do with `getStaticPaths()` today).
+- If a hoisted thing references an un-hoisted variable, error in the compiler saying that exported things must be "pure" (aka can only reference other exported variables).
+- Those exports are now available when you import a component (ex: `import {someExportedConst} from './Main.astro';`)
+- Remove the markdown filtering from `Astro.fetchContent` to now support Astro components and pages as well.
+
+### Open Questions
+
+I think I remember https://github.com/withastro/astro/issues/309 ending with a comment that scoping would be complicated to solve?

--- a/active-rfcs/support-html-files.md
+++ b/active-rfcs/support-html-files.md
@@ -1,0 +1,78 @@
+<!-- LEGACY RFC -->
+<p align="center"><strong>⚠️⚠️⚠️ Legacy RFC Disclaimer ⚠️⚠️⚠️
+<br />This RFC does not meet the requirements of the current RFC process.
+<br />It was accepted before the current process was created.
+<br /><a href="https://github.com/withastro/rfcs#readme">Learn more about the RFC standards.</a>
+</strong></p>
+<!-- LEGACY RFC -->
+
+---
+
+- Start Date: 2021-09-03
+- Reference Issues: N/A
+- Implementation PR: N/A
+
+# Summary
+
+Non-HTML dynamic files.
+
+**Background & Motivation**:
+
+There are many reasons to want custom, dynamic files. One of the primary contenders are JSON feeds and other read-only APIs, because currently there is no clean way to make them. But there is also config files like `.htaccess`, `vercel.config.json` and others to for example [set redirects](https://github.com/snowpackjs/astro/issues/708)! 
+
+Things like image optimization may also play a role (more so in #965, but there are some use cases here too), with something like a frequently changing logo (think google doodles) fetched and processed seperately from the page itself.
+
+**Proposed Solution**:
+
+Sveltekit endpoints.
+To generate a dynamic file `example.com/api/feed.json`
+In sveltekit you would have:
+
+```js
+//   ./src/pages/api/feed.json.ts
+export async function get() {
+  var articles = Astro.fetchcontent("/blog/**/*.md").map(article => /* */)
+  return {
+    body: {
+      JSON.stringify(articles)
+    }
+  };
+}
+```
+
+Can be changed to a more astro-specific API, because headers in SSR... (they could be done with a custom config file though!)
+
+```js
+export async function get() {
+  return "hello world"
+}
+```
+
+```js
+export async function get() {
+  const image = await fetch("example2.com/images/dynamic-logo.php").then(x => x.buffer())
+  return image //also does buffers
+}
+```
+
+By adding a `.js` or `.ts` extension, you make it possible to create any file type with the desired content
+
+**Alternatives considered**:
+
+Discussed in #965, but those would rely on low level components (cough snowpack cough) to make them work correctly
+
+**Risks, downsides, and/or tradeoffs**:
+
+* User-controlled php file (or just injection attacks in general)
+* May be confusing to someone not familiar with sveltekit
+
+**Open Questions**:
+
+* Would it theoretically be possible to use `getstaticpaths` to generate these files? Because `Astro.props` would be exposed and there should be no top-level code, and it should solve most of the usecases presented in #965 and discussed in the RFC call
+
+**Detailed Design**:
+
+> Go back in the git history, right click on the commit that removes the endpoint support, `revert commit`
+> - jasikpark 
+
+Some discussion about this in the last (as of writing) RFC meeting: https://youtu.be/hhsKS2et8Jk?t=1237


### PR DESCRIPTION
This adds the [6 accepted legacy RFCs](https://github.com/withastro/astro/issues?q=is%3Aissue+is%3Aopen+%22RFC%3A%22+in%3Atitle+) from https://github.com/withastro/astro. These RFCs do not meet the requirements of the current RFC process, but they were accepted before the current process was created.

Each legacy RFC includes a notice at the top, with a link to the current RFC standards.

`````markdown
<!-- LEGACY RFC -->
<p align="center"><strong>⚠️⚠️⚠️ Legacy RFC Disclaimer ⚠️⚠️⚠️
<br />This RFC does not meet the requirements of the current RFC process.
<br />It was accepted before the current process was created.
<br /><a href="https://github.com/withastro/rfcs#readme">Learn more about the RFC standards.</a>
</strong></p>
<!-- LEGACY RFC -->

---

`````