### PR TITLE
Finalize <head>, <body>, <html>

### DIFF
--- a/active-rfcs/0000-finalize-head-body.md
+++ b/active-rfcs/0000-finalize-head-body.md
@@ -9,8 +9,11 @@ Finalize behavior around `<head>`, `<body>`, `<html>`, and `<!DOCTYPE html>` ele
 # Motivation
 
 in Astro v0.21, we have had user reports around `<head>` not acting as expected, breaking some projects from v0.20:
+- **Summary:** https://github.com/withastro/astro/issues/2128
 - https://github.com/withastro/astro/issues/2046
 - https://github.com/withastro/astro/issues/2022
+- https://github.com/withastro/astro/issues/2132
+- https://github.com/withastro/astro/issues/2151
 
 Some of these issues stem from undocumented or undefined behaviors in v0.20: was it allowed for `<head>` be conditionally added in a nested expression? 
 

--- a/active-rfcs/0000-finalize-head-body.md
+++ b/active-rfcs/0000-finalize-head-body.md
@@ -15,7 +15,7 @@ in Astro v0.21, we have had user reports around `<head>` not acting as expected,
 Some of these issues stem from undocumented or undefined behaviors in v0.20: was it allowed for `<head>` be conditionally added in a nested expression? 
 
 Other issues stem from our attempt to provide implicit `<head>` and `<body>` support in pages and layouts. There was a quick workaround added for v0.21 where `src/pages` and `src/layouts` folder locations must be defined in config so that our parser knows how to parse them as full HTML documents and not smaller HTML fragments. This unblocked users but at the expense of breaking two larger design goals of the project:
-  - Added `src/layouts` as a new special folder location, when only `src/pages` was intented to be "special".
+  - Added `src/layouts` as a new special folder location, when only `src/pages` was intended to be "special".
   - Caused Astro to create different output for a component based on the file path of that component.
 
 ## Goals

--- a/active-rfcs/0000-finalize-head-body.md
+++ b/active-rfcs/0000-finalize-head-body.md
@@ -8,7 +8,13 @@ Finalize behavior around `<head>`, `<body>`, `<html>`, and `<!DOCTYPE html>` ele
 
 # Motivation
 
-@jonathantneal and I were chatting about [RFC: Finalize v1.0 style and script API for components](https://github.com/withastro/rfcs/pull/12) and discussing `<head>` behavior & bugs in Astro. We came to the realization that only supporting `<head>` in your top-level pages (and not in components) doesn't make sense for anyone using [layout components](https://docs.astro.build/core-concepts/layouts/), which can act as a component but often defines the entire `<head>`. This is a very common use-case for Astro users.
+in Astro v0.21, we have had user reports around `<head>` not acting as expected, breaking some projects from v0.20:
+- https://github.com/withastro/astro/issues/2046
+- https://github.com/withastro/astro/issues/2022
+
+Some of these issues stem from undocumented or undefined behaviors in v0.20, like the fact that `<head>` could be conditional.
+
+This RFC is an attempt to agree on and document the behavior of the `<head>`, `<body>`, and `<html>` tags in a way that makes sense, and can be communicated to users. It should support most common use-cases, such as layouts:
 
 ```astro
 ---
@@ -19,22 +25,33 @@ import CommonLayout from '../layouts/CommonLayout.astro';
 <CommonLayout someProp="..." />
 ```
 
-This was something that we had supported in v0.20, which was accidentally removed as a part of the new compiler. Adding back this behavior could be considered a regression bug fix and not necessarily requiring an RFC (and I think Nate is already working on a fix for this to add back previous behavior), but this feels like a good time to commit to a larger plan around `<head>` and other similar HTML elements.
+## Goals
 
-This same `<head>` problem applies to the `<body>` element, and may also apply to the `<html>` and `<!DOCTYPE html>` elements.
+- Agree on and document the rules and behaviors of the `<head>`, `<body>`, and `<html>` tags.
+- Support any component in the tree adding to the page `<head>`, similar to `<svelte:head>` or head manager libraries in React/Vue. 
+  - (Note: see "Alternatives" for an alternative design if this is decided to be a non-goal).
+
+## Non-Goals
+
+- **Intentionally not implemented:** The ability or option to omit `<body>`, `<head>`, or `<html>` in the final output. This is intentionally not supported here in an effort to reduce complexity around when these tags might or might not be output in your final page HTML. As an Astro user, we assume that you are are comfortable with Astro controlling/optimizing your final HTML output.
+  - If this is sticking point, we can reword this from "intentionally not supported" to "out of scope / possible to implement in the future", but I think it's useful to commit to this behavior as a team if there is no objection.
+- **Out of scope / future:** The ability to author without `<body>`, `<head>`, or `<html>`, and relying on the compiler to handle them like the browser would.  This makes some sense because this is valid in HTML and we try to match HTML semantics whenever possible.  This is currently treated as out-of-scope, but there is nothing here that blocks our ability to do this in the future.
+  - For example, our compiler could automatically detect some elements in the component template (for example, a `<title>`) and auto-hoist it out of the component body and into the `<head>` of the final compiler result to support this.
+- **Out of scope / future:** Intelligent merging of repeated head elements. This is common when a top-level layout `<head>` might define a title, and then a more specific component might overwrite with a more specific `<title>` of its own. This is considered out of scope but not blocked to be implemented in the future.
 
 # Detailed design
 
 - `<head>`
   - A `<head>` element can appear in any component, including pages, layouts, and simple UI components.
+  - The contents of a `<head>` element can be dynamic.
   - Astro will collapse (flatten) all `<head>` elements together from the top-level page to the lowest component into the final page `<head>`.
-  - `<head>` elements are collected and printed in breadth-first order.
-  - If no `<head>` elements are found in the final output, none will be output to the page.
+  - `<head>` elements are collected and and printed in the order that the components appear on the page.
+  - If no `<head>` elements are used by the author, no head will be output to the page.
   - This solves for the page layout problem AND gives us new head management support, similar to [`<svelte:head>`](https://svelte.dev/docs#svelte_head)
 - `<body>`
   - completely ignored in a component template
   - a `<body>` tag is always included in the final output
-  - everything in the component template is assumed to be the body
+  - everything in the component template is assumed to be the body, other than the other elements listed here
 - `<html>`
   - completely ignored in a component template
   - an `<html>` tag is always included in the final output
@@ -42,19 +59,27 @@ This same `<head>` problem applies to the `<body>` element, and may also apply t
   - completely ignored in a component template
   - a `<!DOCTYPE html>` tag is always included in the final output
 
+## Implementation
+
+Similar to how the Svelte compiler works, `head` elements would be collected in a `result.head` property by the compiler, seperate from the body of the template. 
+
+The runtime would collect these across all rendered components on the page, and at the end of the page render would have the final collapsed `head` to print to the page. 
+
 # Drawbacks
 
 - `<head>` ordering - I'm not sure if this is easy to implement. Could use a prototype or expert set of eyes :)
-- There's a small amount of interest in supporting developers who do not want their output to include `<body>`, `<head>`, or `<html>` in the final output. This is intentionally not supported by this proposal in an effort to reduce complexity. This is understood to be mostly for vanity (the bytes saved are minor) and as an Astro user you are already comfortable with Astro controlling/optimizing your final output. 
-  - If this is sticking point, we can reword this from "intentionally not supported" to "out of scope / possible to implement in the future", but I think it's important to commit to this behavior as a team if there is no objection.
-- There's a slightly larger amount of interest in supporting developers who do not want to their output to include `<body>`, `<head>`, or `<html>` in the templates, and instead relying on the compiler to handle this for them.  This makes some sense because this is valid in HTML and we try to match HTML semantics whenever possible.  This is currently treated as out-of-scope, but there is nothing here that blocks our ability to do this in the future. 
-  - For example, our compiler could automatically detect some elements in the component template (for example, a `<title>`) and auto-hoist it out of the component body and into the `<head>` of the final compiler result to support this.
+- Does not support Streaming HTML for SSR. See "No `<head>` Collapsing" for an alternative approach that addresses this drawback. 
 
 # Alternatives
 
-- Do we warn if `<body>` _NEVER_ appears in the page's rendered component tree? appears twice?
-  - @jonathantneal made the good point that `<body>` isn't actually required for valid HTML
-- Do we warn if `<html>` _NEVER_ appears in the page's rendered component tree? appears twice?
+## No `<head>` Collapsing
+
+It is a goal to allow all components to add elements directly to `<head>`. If we remove this goal, then then we could consider a design that only allows one component to act as "page layout" and set the `<html>`, `<head>` and `<body>` tags and then all other components are just fragments, always assumed to be a part of the body. There seems to be interest in this goal from the community (see linked discussion for more) but this could still be up for debate if there is interest.
+
+One reason to consider this is that it would make naive HTML streaming easier once we move to SSR. We could respond with the first component's `<head>` contents as soon as that one component renders, and then we would stream down its body as it rendered. As written, the current proposal does not support this since the head could be modified at any point in the document.
+
+This may be much easier to implement in the current compiler, which would be a factor to consider. Looking for feedback on this.
+
 
 # Adoption strategy
 
@@ -62,4 +87,7 @@ This same `<head>` problem applies to the `<body>` element, and may also apply t
 
 # Unresolved questions
 
-- None yet.
+
+- Do we warn if `<body>` _NEVER_ appears in the page's rendered component tree? appears twice?
+  - @jonathantneal made the good point that `<body>` isn't actually required for valid HTML
+- Do we warn if `<html>` _NEVER_ appears in the page's rendered component tree? appears twice?

--- a/active-rfcs/0000-finalize-head-body.md
+++ b/active-rfcs/0000-finalize-head-body.md
@@ -58,7 +58,7 @@ In this design it is more "on you" to write valid HTML. This comes from the real
 
 # Alternatives
 
-- Forcing that a user includes `<html>`, `<body>` and `<head>` elements in the final page output. This could be explored as an optional lint rule, however there is not currently consensus around this idea and also there is no known objective value in this from a compiler or runtime standpoint. If this is desired, it should be considered a seperate feature request and out of scope from this RFC.
+- Forcing that a user includes `<html>`, `<body>` and `<head>` elements in the final page output. This could be explored more, however there is not currently consensus around this idea and also there is no known reason to tackle this as a part of this RFC. If this is desired, it should be considered a seperate feature request and out of scope from this RFC.
 
 # Adoption strategy
 

--- a/active-rfcs/0000-finalize-head-body.md
+++ b/active-rfcs/0000-finalize-head-body.md
@@ -54,7 +54,7 @@ In this design it is more "on you" to write valid HTML. This comes from the real
 # Drawbacks
 
 - This RFC will allow you to author a page of HTML that does not actually output `<html>`, `<body>` or `<head>` elements. This can be considered an advantage in that it is more flexible than something like Svelte or Vue. However, it means we need to be more diligent with testing this kind of output across our codebase and dependencies. For example, we would need to confirm that Vite does not have trouble injecting things into an HTML document without a head or body.
-  - If we are blocked by this limitation in some way and can't reasonably unblock (for example, a non-trivial Vite limitaiton) this RFC states that it would be acceptable for Astro to add `<head>` or `<body>` elements in a way that keeps the output HTML valid but unblocks Astro.
+  - If we are blocked by this limitation in some way and can't reasonably unblock (for example, a non-trivial Vite limitaiton) this RFC states that it would be acceptable for Astro to add or require a `<head>` or `<body>` element in the final output HTML in a way that keeps the output HTML valid but unblocks Astro/tooling. Reminder that it is not an explicit goal to support authoring with `<head>` or `<body>`, but it is something that we would like to support if we reasonably can.
 
 # Alternatives
 

--- a/active-rfcs/0000-finalize-head-body.md
+++ b/active-rfcs/0000-finalize-head-body.md
@@ -36,11 +36,13 @@ Other issues stem from our attempt to provide implicit `<head>` and `<body>` sup
 - `<!DOCTYPE html>`
   - compiler: completely ignored by the compiler, stripped out from render output.
   - runtime: a `<!DOCTYPE html>` tag is always included in final page HTML output.
-- `<html>`, `<body>`, `<head>`
+- `<html>`, `<body>`
   - compiler: will be left as-is in the component template.
   - runtime: will be left as-is in final page HTML output.
-  - runtime: will warn if no `head` tag is rendered by an Astro component for an entire page.
-  - runtime: may warn if duplicate `html`, `body`, and `head` tags are rendered inside of Astro components for an entire page.
+- `<head>`
+  - runtime: element is always required in final page output for style/script injection.
+  - runtime: will warn if `head` tag is not rendered exactly once for an entire page.
+  - `<head>` not supported inside of a non-Astro components. Non-Astro components could generate `<head>` contents, like `<link>` or `<meta>`, but not the `<head>` element itself.
 
 ## Compiler Changes
 
@@ -53,7 +55,6 @@ Losing `"as": "document"` parse mode will remove some special parser handling, l
 In this design it is more "on you" to write valid HTML. This comes from the reality that an imported component can contain unknown HTML, so the compiler can't implicitly assume anything about what is or is not included included the final parent component template.  See https://github.com/withastro/astro/issues/2022 for examples of when this breaks down today. We can help with some static linting, and runtime warnings if the final HTML output is invalid. However, this RFC acknowledges the reality that already exists in v0.21 that imported components break any assumptions and help that we previously attempted to provide.
 
 ## Head Injection Changes
-
 - runtime: will remove current post-build head injection, which involves a fragile `'</head>'` string find-and-replace.
 - compiler: will add a new `head: string` (or: `injectHead(): string`) property to the compiler transform options, which will inject the given HTML string into the bottom of a `<head>` element, if one is return by the compiler.
 - runtime: will provide this value head injection value to the compiler, and throw an exception if not used/called exactly once during a page render. 

--- a/active-rfcs/0000-finalize-head-body.md
+++ b/active-rfcs/0000-finalize-head-body.md
@@ -12,79 +12,69 @@ in Astro v0.21, we have had user reports around `<head>` not acting as expected,
 - https://github.com/withastro/astro/issues/2046
 - https://github.com/withastro/astro/issues/2022
 
-Some of these issues stem from undocumented or undefined behaviors in v0.20, like the fact that `<head>` could be conditional.
+Some of these issues stem from undocumented or undefined behaviors in v0.20: was it allowed for `<head>` be conditionally added in a nested expression? 
 
-This RFC is an attempt to agree on and document the behavior of the `<head>`, `<body>`, and `<html>` tags in a way that makes sense, and can be communicated to users. It should support most common use-cases, such as layouts:
-
-```astro
----
-// src/pages/index.astro
-import CommonLayout from '../layouts/CommonLayout.astro';
----
-<!-- this is valid, where CommonLayout contains `<head>`, `<body>`, etc.
-<CommonLayout someProp="..." />
-```
+Other issues stem from our attempt to provide implicit `<head>` and `<body>` support in pages and layouts. There was a quick workaround added for v0.21 where `src/pages` and `src/layouts` folder locations must be defined in config so that our parser knows how to parse them as full HTML documents and not smaller HTML fragments. This unblocked users but at the expense of breaking two larger design goals of the project:
+  - Added `src/layouts` as a new special folder location, when only `src/pages` was intented to be "special".
+  - Caused Astrp to create different output for a component based on the file path of that component.
 
 ## Goals
 
-1. Agree on and document the rules and behaviors of the `<head>`, `<body>`, and `<html>` tags.
-2. Support any component in the tree adding to the page `<head>`, similar to `<svelte:head>` or head manager libraries in React/Vue. (Note: see "Alternatives" for an alternative design if this is decided to be a non-goal).
+1. Agree on and document the rules and behaviors of the `<head>`, `<body>`, `<html>`, and `<!DOCTYPE html>` tags.
+2. Remove special compiler behavior based on where a file lives in your src directory. 
+3. Remove `src/layouts` as a "special" folder and any config around this.
 
 ## Non-Goals
 
-1. **Intentionally not implemented:** The ability or option to omit `<body>`, `<head>`, or `<html>` in the final output. This is intentionally not supported here in an effort to reduce complexity around when these tags might or might not be output in your final page HTML. As an Astro user, we assume that you are are comfortable with Astro controlling/optimizing your final HTML output.  
-  • If this is sticking point, we can reword this from "intentionally not supported" to "out of scope / possible to implement in the future", but I think it's useful to commit to this behavior as a team if there is no objection.
-1. **Out of scope / future:** The ability to author without `<body>`, `<head>`, or `<html>`, and relying on the compiler to handle them like the browser would.  This makes some sense because this is valid in HTML and we try to match HTML semantics whenever possible.  This is currently treated as out-of-scope, but there is nothing here that blocks our ability to do this in the future.  
-  • For example, our compiler could automatically detect some elements in the component template (for example, a `<title>`) and auto-hoist it out of the component body and into the `<head>` of the final compiler result to support this.
-1. **Out of scope / future:** Intelligent merging of repeated head elements. This is common when a top-level layout `<head>` might define a title, and then a more specific component might overwrite with a more specific `<title>` of its own. This is considered out of scope but not blocked to be implemented in the future.
+1. **Out of scope:** Support `<head>` Injection inside of individual components. This is a commonly requested user feature, but can be tackled as an additional feature, leaving this RFC focused on clarifying our existing API. This RFC does not impact that feature request.
+
 
 # Detailed design
 
-- `<head>`
-  - A `<head>` element can appear in any component, including pages, layouts, and simple UI components.
-  - The contents of a `<head>` element can be dynamic.
-  - Astro will collapse (flatten) all `<head>` elements together from the top-level page to the lowest component into the final page `<head>`.
-  - `<head>` elements are collected and and printed in the order that the components appear on the page.
-  - If no `<head>` elements are used by the author, no head will be output to the page.
-  - This solves for the page layout problem AND gives us new head management support, similar to [`<svelte:head>`](https://svelte.dev/docs#svelte_head)
-- `<body>`
-  - completely ignored in a component template
-  - a `<body>` tag is always included in the final output
-  - everything in the component template is assumed to be the body, other than the other elements listed here
-- `<html>`
-  - completely ignored in a component template
-  - an `<html>` tag is always included in the final output
+## Template Changes
+
 - `<!DOCTYPE html>`
-  - completely ignored in a component template
-  - a `<!DOCTYPE html>` tag is always included in the final output
+  - compiler: completely ignored by the compiler, stripped out from render output.
+  - runtime: a `<!DOCTYPE html>` tag is always included in final page HTML output.
+- `<html>`, `<body>`, `<head>`
+  - compiler: will be left as-is in the component template.
+  - runtime: will be left as-is in final page HTML output.
+  - runtime: may warn if duplicate `html`, `body`, and `head` tags are included in final page HTML output.
 
-## Implementation
+## Compiler Changes
 
-Similar to how the Svelte compiler works, `head` elements would be collected in a `result.head` property by the compiler, seperate from the body of the template. 
+- `src/pages` and `src/layouts` will no longer be parsed or rendered differently from other components
+- `as?: 'document' | 'fragment';` will be removed from the compiler.
+- All Astro components will now be compiled as fragments.
 
-The runtime would collect these across all rendered components on the page, and at the end of the page render would have the final collapsed `head` to print to the page. 
+Losing `"as": "document"` parse mode will remove some special parser handling, like getting an implicit `<head>` to wrap a standalone `<title>` element. This is intentional to bring us more inline with the RFC, where we respect the HTML authored by the developer as the source of truth and leave mostly as-is in the final output.
+
+In this design it is more "on you" to write valid HTML. This comes from the reality that an imported component can contain unknown HTML, so the compiler can't implicitly assume anything about what is or is not included included the final parent component template.  See https://github.com/withastro/astro/issues/2022 for examples of when this breaks down today. We can help with some static linting, and runtime warnings if the final HTML output is invalid. However, this RFC acknowledges the reality that already exists in v0.21 that imported components break any assumptions and help that we previously attempted to provide.
 
 # Drawbacks
 
-1. `<head>` ordering - I'm not sure if this is easy to implement. Could use a prototype or expert set of eyes :)
-2. Does not support Streaming HTML for SSR. See "No `<head>` Collapsing" for an alternative approach that addresses this drawback. 
+- This RFC will allow you to author a page of HTML that does not actually output `<html>`, `<body>` or `<head>` elements. This can be considered an advantage in that it is more flexible than something like Svelte or Vue. However, it means we need to be more diligent with testing this kind of output across our codebase and dependencies. For example, we would need to confirm that Vite does not have trouble injecting things into an HTML document without a head or body.
+  - If we are blocked by this limitation in some way and can't reasonably unblock (for example, a non-trivial Vite limitaiton) this RFC states that it would be acceptable for Astro to add `<head>` or `<body>` elements in a way that keeps the output HTML valid but unblocks Astro. This would not be done unless absolutely necessary. 
 
 # Alternatives
 
-## 1. No `<head>` Collapsing
-
-It is a goal to allow all components to add elements directly to `<head>`. If we remove this goal, then then we could consider a design that only allows one component to act as "page layout" and set the `<html>`, `<head>` and `<body>` tags and then all other components are just fragments, always assumed to be a part of the body. There seems to be interest in this goal from the community (see linked discussion for more) but this could still be up for debate if there is interest.
-
-One reason to consider this is that it would make naive HTML streaming easier once we move to SSR. We could respond with the first component's `<head>` contents as soon as that one component renders, and then we would stream down its body as it rendered. As written, the current proposal does not support this since the head could be modified at any point in the document.
-
-This may be much easier to implement in the current compiler, which would be a factor to consider. Looking for feedback on this.
-
+- Forcing that a user includes `<html>`, `<body>` and `<head>` elements in the final page output. This could be explored as an optional lint rule, however there is not currently consensus around this idea and also there is no known objective value in this from a compiler or runtime standpoint. If this is desired, it should be considered a seperate feature request and out of scope from this RFC.
 
 # Adoption strategy
 
-- This proposal is more relaxed than our existing rules, so this shouldn't be a breaking change for any existing users.
+This proposal is not too far off from current behavior, so direct impact on the user is expected to be minimal. However, removing `document` mode may break some users relying on certain side-effects and indirect Astro compiler behavior. 
+
+To mitigate this, this RFC proposes the following release plan:
+
+1. In a well-tested PR to astro core, remove any usage of `as: 'document'` when calling the compiler.
+2. Release this in a new minor release. This would be the only thing to go out in this release.
+3. Explicitly mention the breakage potential in the release notes, and on Discord.
+
+If any users report breakage, who cannot easily update their project to fix: 
+1. Those users can stay on the previous version while we work to add a config fallback to continue to use `document` for pages and layouts
+
+Once settled, we would remove the now-unnecesary `layouts` config and remove `as: "document"` support from the compiler in followup minor releases.
 
 # Unresolved questions
 
-1. Do we warn if `<body>` _NEVER_ appears in the page's rendered component tree? appears twice? @jonathantneal made the good point that `<body>` isn't actually required for valid HTML.
-2. Do we warn if `<html>` _NEVER_ appears in the page's rendered component tree? appears twice?
+- None yet.

--- a/active-rfcs/0000-finalize-head-body.md
+++ b/active-rfcs/0000-finalize-head-body.md
@@ -16,7 +16,7 @@ Some of these issues stem from undocumented or undefined behaviors in v0.20: was
 
 Other issues stem from our attempt to provide implicit `<head>` and `<body>` support in pages and layouts. There was a quick workaround added for v0.21 where `src/pages` and `src/layouts` folder locations must be defined in config so that our parser knows how to parse them as full HTML documents and not smaller HTML fragments. This unblocked users but at the expense of breaking two larger design goals of the project:
   - Added `src/layouts` as a new special folder location, when only `src/pages` was intented to be "special".
-  - Caused Astrp to create different output for a component based on the file path of that component.
+  - Caused Astro to create different output for a component based on the file path of that component.
 
 ## Goals
 

--- a/active-rfcs/0000-finalize-head-body.md
+++ b/active-rfcs/0000-finalize-head-body.md
@@ -27,17 +27,16 @@ import CommonLayout from '../layouts/CommonLayout.astro';
 
 ## Goals
 
-- Agree on and document the rules and behaviors of the `<head>`, `<body>`, and `<html>` tags.
-- Support any component in the tree adding to the page `<head>`, similar to `<svelte:head>` or head manager libraries in React/Vue. 
-  - (Note: see "Alternatives" for an alternative design if this is decided to be a non-goal).
+1. Agree on and document the rules and behaviors of the `<head>`, `<body>`, and `<html>` tags.
+2. Support any component in the tree adding to the page `<head>`, similar to `<svelte:head>` or head manager libraries in React/Vue. (Note: see "Alternatives" for an alternative design if this is decided to be a non-goal).
 
 ## Non-Goals
 
-- **Intentionally not implemented:** The ability or option to omit `<body>`, `<head>`, or `<html>` in the final output. This is intentionally not supported here in an effort to reduce complexity around when these tags might or might not be output in your final page HTML. As an Astro user, we assume that you are are comfortable with Astro controlling/optimizing your final HTML output.
-  - If this is sticking point, we can reword this from "intentionally not supported" to "out of scope / possible to implement in the future", but I think it's useful to commit to this behavior as a team if there is no objection.
-- **Out of scope / future:** The ability to author without `<body>`, `<head>`, or `<html>`, and relying on the compiler to handle them like the browser would.  This makes some sense because this is valid in HTML and we try to match HTML semantics whenever possible.  This is currently treated as out-of-scope, but there is nothing here that blocks our ability to do this in the future.
-  - For example, our compiler could automatically detect some elements in the component template (for example, a `<title>`) and auto-hoist it out of the component body and into the `<head>` of the final compiler result to support this.
-- **Out of scope / future:** Intelligent merging of repeated head elements. This is common when a top-level layout `<head>` might define a title, and then a more specific component might overwrite with a more specific `<title>` of its own. This is considered out of scope but not blocked to be implemented in the future.
+1. **Intentionally not implemented:** The ability or option to omit `<body>`, `<head>`, or `<html>` in the final output. This is intentionally not supported here in an effort to reduce complexity around when these tags might or might not be output in your final page HTML. As an Astro user, we assume that you are are comfortable with Astro controlling/optimizing your final HTML output.  
+  • If this is sticking point, we can reword this from "intentionally not supported" to "out of scope / possible to implement in the future", but I think it's useful to commit to this behavior as a team if there is no objection.
+1. **Out of scope / future:** The ability to author without `<body>`, `<head>`, or `<html>`, and relying on the compiler to handle them like the browser would.  This makes some sense because this is valid in HTML and we try to match HTML semantics whenever possible.  This is currently treated as out-of-scope, but there is nothing here that blocks our ability to do this in the future.  
+  • For example, our compiler could automatically detect some elements in the component template (for example, a `<title>`) and auto-hoist it out of the component body and into the `<head>` of the final compiler result to support this.
+1. **Out of scope / future:** Intelligent merging of repeated head elements. This is common when a top-level layout `<head>` might define a title, and then a more specific component might overwrite with a more specific `<title>` of its own. This is considered out of scope but not blocked to be implemented in the future.
 
 # Detailed design
 
@@ -67,12 +66,12 @@ The runtime would collect these across all rendered components on the page, and 
 
 # Drawbacks
 
-- `<head>` ordering - I'm not sure if this is easy to implement. Could use a prototype or expert set of eyes :)
-- Does not support Streaming HTML for SSR. See "No `<head>` Collapsing" for an alternative approach that addresses this drawback. 
+1. `<head>` ordering - I'm not sure if this is easy to implement. Could use a prototype or expert set of eyes :)
+2. Does not support Streaming HTML for SSR. See "No `<head>` Collapsing" for an alternative approach that addresses this drawback. 
 
 # Alternatives
 
-## No `<head>` Collapsing
+## 1. No `<head>` Collapsing
 
 It is a goal to allow all components to add elements directly to `<head>`. If we remove this goal, then then we could consider a design that only allows one component to act as "page layout" and set the `<html>`, `<head>` and `<body>` tags and then all other components are just fragments, always assumed to be a part of the body. There seems to be interest in this goal from the community (see linked discussion for more) but this could still be up for debate if there is interest.
 
@@ -87,7 +86,5 @@ This may be much easier to implement in the current compiler, which would be a f
 
 # Unresolved questions
 
-
-- Do we warn if `<body>` _NEVER_ appears in the page's rendered component tree? appears twice?
-  - @jonathantneal made the good point that `<body>` isn't actually required for valid HTML
-- Do we warn if `<html>` _NEVER_ appears in the page's rendered component tree? appears twice?
+1. Do we warn if `<body>` _NEVER_ appears in the page's rendered component tree? appears twice? @jonathantneal made the good point that `<body>` isn't actually required for valid HTML.
+2. Do we warn if `<html>` _NEVER_ appears in the page's rendered component tree? appears twice?

--- a/active-rfcs/0000-finalize-head-body.md
+++ b/active-rfcs/0000-finalize-head-body.md
@@ -1,0 +1,65 @@
+- Start Date: 11/30/2021
+- Reference Issues: https://github.com/withastro/rfcs/discussions/15
+- Implementation PR:
+
+# Summary
+
+Finalize behavior around `<head>`, `<body>`, `<html>`, and `<!DOCTYPE html>` elements in Astro component templates.
+
+# Motivation
+
+@jonathantneal and I were chatting about [RFC: Finalize v1.0 style and script API for components](https://github.com/withastro/rfcs/pull/12) and discussing `<head>` behavior & bugs in Astro. We came to the realization that only supporting `<head>` in your top-level pages (and not in components) doesn't make sense for anyone using [layout components](https://docs.astro.build/core-concepts/layouts/), which can act as a component but often defines the entire `<head>`. This is a very common use-case for Astro users.
+
+```astro
+---
+// src/pages/index.astro
+import CommonLayout from '../layouts/CommonLayout.astro';
+---
+<!-- this is valid, where CommonLayout contains `<head>`, `<body>`, etc.
+<CommonLayout someProp="..." />
+```
+
+This was something that we had supported in v0.20, which was accidentally removed as a part of the new compiler. Adding back this behavior could be considered a regression bug fix and not necessarily requiring an RFC (and I think Nate is already working on a fix for this to add back previous behavior), but this feels like a good time to commit to a larger plan around `<head>` and other similar HTML elements.
+
+This same `<head>` problem applies to the `<body>` element, and may also apply to the `<html>` and `<!DOCTYPE html>` elements.
+
+# Detailed design
+
+- `<head>`
+  - A `<head>` element can appear in any component, including pages, layouts, and simple UI components.
+  - Astro will collapse (flatten) all `<head>` elements together from the top-level page to the lowest component into the final page `<head>`.
+  - `<head>` elements are collected and printed in breadth-first order.
+  - If no `<head>` elements are found in the final output, none will be output to the page.
+  - This solves for the page layout problem AND gives us new head management support, similar to [`<svelte:head>`](https://svelte.dev/docs#svelte_head)
+- `<body>`
+  - completely ignored in a component template
+  - a `<body>` tag is always included in the final output
+  - everything in the component template is assumed to be the body
+- `<html>`
+  - completely ignored in a component template
+  - an `<html>` tag is always included in the final output
+- `<!DOCTYPE html>`
+  - completely ignored in a component template
+  - a `<!DOCTYPE html>` tag is always included in the final output
+
+# Drawbacks
+
+- `<head>` ordering - I'm not sure if this is easy to implement. Could use a prototype or expert set of eyes :)
+- There's a small amount of interest in supporting developers who do not want their output to include `<body>`, `<head>`, or `<html>` in the final output. This is intentionally not supported by this proposal in an effort to reduce complexity. This is understood to be mostly for vanity (the bytes saved are minor) and as an Astro user you are already comfortable with Astro controlling/optimizing your final output. 
+  - If this is sticking point, we can reword this from "intentionally not supported" to "out of scope / possible to implement in the future", but I think it's important to commit to this behavior as a team if there is no objection.
+- There's a slightly larger amount of interest in supporting developers who do not want to their output to include `<body>`, `<head>`, or `<html>` in the templates, and instead relying on the compiler to handle this for them.  This makes some sense because this is valid in HTML and we try to match HTML semantics whenever possible.  This is currently treated as out-of-scope, but there is nothing here that blocks our ability to do this in the future. 
+  - For example, our compiler could automatically detect some elements in the component template (for example, a `<title>`) and auto-hoist it out of the component body and into the `<head>` of the final compiler result to support this.
+
+# Alternatives
+
+- Do we warn if `<body>` _NEVER_ appears in the page's rendered component tree? appears twice?
+  - @jonathantneal made the good point that `<body>` isn't actually required for valid HTML
+- Do we warn if `<html>` _NEVER_ appears in the page's rendered component tree? appears twice?
+
+# Adoption strategy
+
+- This proposal is more relaxed than our existing rules, so this shouldn't be a breaking change for any existing users.
+
+# Unresolved questions
+
+- None yet.

--- a/active-rfcs/0000-finalize-head-body.md
+++ b/active-rfcs/0000-finalize-head-body.md
@@ -54,7 +54,7 @@ In this design it is more "on you" to write valid HTML. This comes from the real
 # Drawbacks
 
 - This RFC will allow you to author a page of HTML that does not actually output `<html>`, `<body>` or `<head>` elements. This can be considered an advantage in that it is more flexible than something like Svelte or Vue. However, it means we need to be more diligent with testing this kind of output across our codebase and dependencies. For example, we would need to confirm that Vite does not have trouble injecting things into an HTML document without a head or body.
-  - If we are blocked by this limitation in some way and can't reasonably unblock (for example, a non-trivial Vite limitaiton) this RFC states that it would be acceptable for Astro to add `<head>` or `<body>` elements in a way that keeps the output HTML valid but unblocks Astro. This would not be done unless absolutely necessary. 
+  - If we are blocked by this limitation in some way and can't reasonably unblock (for example, a non-trivial Vite limitaiton) this RFC states that it would be acceptable for Astro to add `<head>` or `<body>` elements in a way that keeps the output HTML valid but unblocks Astro.
 
 # Alternatives
 

--- a/active-rfcs/0000-finalize-head-body.md
+++ b/active-rfcs/0000-finalize-head-body.md
@@ -56,9 +56,30 @@ In this design it is more "on you" to write valid HTML. This comes from the real
 
 - runtime: will remove current post-build head injection, which involves a fragile `'</head>'` string find-and-replace.
 - compiler: will add a new `head: string` (or: `injectHead(): string`) property to the compiler transform options, which will inject the given HTML string into the bottom of a `<head>` element, if one is return by the compiler.
-- runtime: will provide this value head injection value to the compiler, and throw an exception if not used/called exactly once during a page render.
+- runtime: will provide this value head injection value to the compiler, and throw an exception if not used/called exactly once during a page render. 
 
 The Astro runtime will use this new property to inject all CSS styles used by components on the page into the final HTML document. These may be individual file `<link>` or `<style>` tags during development, or a few bundled CSS files in your final production build.
+
+Note: This must handle a `<slot>` containing a `<head>` and/or `<head slot="head">`. If this is too difficult to handle during implementation, we could also consider disallowing `<head slot="head">` in favor of the slot living inside of the head:
+
+```astro
+<!-- If needed for head injection, error on  `<head slot="head">` -->
+<slot name="head">
+  <head>
+    <!-- ... -->
+  </head>
+</slot>
+<head slot="head">
+
+<!-- In favor of this: -->
+<head>
+  <slot name="head">
+    <!-- ... -->
+  </slot>
+</head>
+<link slot="head" ... />
+```
+
 
 
 # Drawbacks


### PR DESCRIPTION
- Start Date: 2021-11-30
- Status: Draft

## Summary

Finalize behavior around `<head>`, `<body>`, `<html>`, and `<!DOCTYPE html>` elements in Astro component templates.

## Links

- [Full Rendered Proposal](https://github.com/withastro/rfcs/blob/FredKSchott-patch-2/active-rfcs/0000-finalize-head-body.md)
