### PR TITLE
0019: Unify markdown plugins into a single array

### DIFF
--- a/proposals/0019-config-finalization.md
+++ b/proposals/0019-config-finalization.md
@@ -114,6 +114,7 @@ This RFC proposes:
   > Internally this may be implemented in a pluggable manner, but that's an implementation detail.
 - Move the `render[1]` options object to the top-level.
 - Move `buildOptions.draft` => `markdown.drafts`
+- Unify `remarkPlugins` and `rehypePlugins` into `plugins`.
 
 # Sitemap
 


### PR DESCRIPTION
## Summary

Update to 0019

Our markdown integration [doesn't distinguish](https://github.com/withastro/astro/blob/23b8ee2738076225da57ce5e3826373c8964717c/packages/markdown/remark/src/index.ts#L59-L60) Remark from Rehype plugins, so maybe it's better to have them in a single array

## Links

<!--
  Link to a GitHub-rendered version of your RFC, e.g.
  https://github.com/<USERNAME>/rfcs/blob/<BRANCH>/active-rfcs/0000-my-proposal.md
  You can find this link by navigating to this file on your branch.
-->

- [Full Rendered Proposal](https://github.com/withastro/rfcs/blob/0019/markdown-plugins/proposals/0019-config-finalization.md)
