### PR TITLE
Add testing section to the RFC template

### DIFF
--- a/template.md
+++ b/template.md
@@ -33,6 +33,12 @@ implementation to implement. This should get into specifics and corner-cases,
 and include examples of how the feature is used. Any new terminology should be
 defined here.
 
+# Testing strategy
+
+How will this feature's implementation be tested? Explain if this can be tested with
+unit tests or integration tests or something else. If relevant, explain the test
+cases that will be added to cover all of the ways this feature might be used.
+
 # Drawbacks
 
 Why should we *not* do this? Please consider:


### PR DESCRIPTION
This is not a new RFC but a proposed change to the template.

It adds an explicit section on testing strategies. As Astro grows the cost of new features also grows. Knowing how a feature will be tested gives us greater confidence that the feature will be easy to maintain and fewer regressions will occur. This also forces the RFC creator to think through edge cases they might otherwise gloss over.